### PR TITLE
Use postcss-safe-parser

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const postcss = require('postcss')
+const safe = require('postcss-safe-parser')
 const mergeLonghand = require('postcss-merge-longhand')
 
 module.exports = (options = {}) => tree => {
@@ -14,7 +15,7 @@ module.exports = (options = {}) => tree => {
     }
 
     if (node.attrs && node.attrs.style) {
-      const {css} = postcss().use(mergeLonghand).process(`div { ${node.attrs.style} }`)
+      const {css} = postcss().use(mergeLonghand).process(`div { ${node.attrs.style} }`, {parser: safe})
       node.attrs.style = css.replace(/div {\s|\s}$/gm, '')
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "postcss": "^8.1.10",
         "postcss-merge-longhand": "^6.0.0",
+        "postcss-safe-parser": "^7.0.0",
         "posthtml": "^0.16.4"
       },
       "devDependencies": {
@@ -8569,6 +8570,31 @@
       },
       "engines": {
         "node": "^14 || ^16 || >=18.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.31"
+      }
+    },
+    "node_modules/postcss-safe-parser": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-7.0.0.tgz",
+      "integrity": "sha512-ovehqRNVCpuFzbXoTb4qLtyzK3xn3t/CUBxOs8LsnQjQrShaB4lKiHoVqY8ANaC0hBMHq5QVWk77rwGklFUDrg==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss-safe-parser"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "engines": {
+        "node": ">=18.0"
       },
       "peerDependencies": {
         "postcss": "^8.4.31"
@@ -17872,6 +17898,12 @@
         "postcss-value-parser": "^4.2.0",
         "stylehacks": "^6.0.2"
       }
+    },
+    "postcss-safe-parser": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-7.0.0.tgz",
+      "integrity": "sha512-ovehqRNVCpuFzbXoTb4qLtyzK3xn3t/CUBxOs8LsnQjQrShaB4lKiHoVqY8ANaC0hBMHq5QVWk77rwGklFUDrg==",
+      "requires": {}
     },
     "postcss-selector-parser": {
       "version": "6.0.15",

--- a/package.json
+++ b/package.json
@@ -23,13 +23,15 @@
     "postcss",
     "inline-styles",
     "inline-css",
-    "inline-css",
+    "merge-styles",
+    "merge-css",
     "longhand",
     "shorthand"
   ],
   "dependencies": {
     "postcss": "^8.1.10",
     "postcss-merge-longhand": "^6.0.0",
+    "postcss-safe-parser": "^7.0.0",
     "posthtml": "^0.16.4"
   },
   "devDependencies": {

--- a/test/expected/parser.html
+++ b/test/expected/parser.html
@@ -1,0 +1,1 @@
+<div style="margin: 0 auto">margin</div>

--- a/test/fixtures/parser.html
+++ b/test/fixtures/parser.html
@@ -1,0 +1,1 @@
+<div style="margin-top: 0; margin-bottom: 0 margin-left: auto; margin-right: auto">margin</div>

--- a/test/test.js
+++ b/test/test.js
@@ -27,3 +27,7 @@ test('Preserves other properties', t => {
 test('Works with tags option', t => {
   return process(t, 'tags', {tags: ['div', 'p']})
 })
+
+test('Works with bad CSS', t => {
+  return process(t, 'parser')
+})


### PR DESCRIPTION
This PR adds `postcss-safe-parser` to the PostCSS `process` method options, so that potentially-malformed CSS strings are handled better. Since HTML emails in particular may contain CSS hacks that the defaut PostCSS parser might not like, it makes sense to use the safe parser.

Noticed this in Maizzle in a scenario where the CSS for this plugin to handle was basically missing a semicolon in the middle:

```html
<div style="margin-top: 0; margin-bottom: 0 margin-left: auto; margin-right: auto">margin</div>
```

That resulted in a `CssSyntaxError`:

```sh
CssSyntaxError {
  column: 44,
  input: {
    column: 44,
    endColumn: undefined,
    endLine: undefined,
    line: 1,
    source: 'div { margin-left: auto; margin-right: auto margin-left: auto; margin-right: auto }',
  },
  line: 1,
  reason: 'Missed semicolon',
  source: 'div { margin-left: auto; margin-right: auto margin-left: auto; margin-right: auto }',
  message: '<css input>:1:44: Missed semicolon',
}
```